### PR TITLE
Add html field type

### DIFF
--- a/Types/FieldType.php
+++ b/Types/FieldType.php
@@ -94,6 +94,7 @@ class FieldType {
             case 'color':
             case 'colortag':
             case 'select':
+            case 'html':
 
                 if ($field['type'] == 'text' && isset($field['options']['type']) && $field['options']['type'] == 'number') {
                     $def['type'] = Type::int();


### PR DESCRIPTION
`HTML` field type is basically the same as `WYSIWYG` (in terms of markup output), so it should be fine to be handled the same way.