### PR TITLE
Add installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
+# Installation
+
+Via Cockpit CLI (Cockpit 0.9.1 or greater):
+```
+./cp install/addon --name CockpitQL
+```
+
+Manually:
+- download the repository;
+- add it as a subfolder to the `./addons` directory.
+
+Either way, the final tree should look as follows:
+```
+user@pc:/path/to/cockpit/folder$ tree -d -L 2 -n
+.
+├── addons
+│   └── CockpitQL
+...
+```
+
 # Api
 
 GraphQL entry point:


### PR DESCRIPTION
Since it was unclear to many, I decided - to prevent the rise of new issues on the same line of #19 and #21 - to add some installation instructions to the `README.md` file.