### PR TITLE
Remove resolver of `collectionlink` field

### DIFF
--- a/Types/FieldType.php
+++ b/Types/FieldType.php
@@ -199,7 +199,13 @@ class FieldType {
                 }
 
                 $linkType = self::collectionLinkFieldType($field['options']['link'], $field, $collection);
-                $def['type'] = $linkType;
+                $isMultiple = isset($field['options']['multiple']) && $field['options']['multiple'];
+                $def['type'] = $isMultiple ? Type::listOf($linkType) : $linkType;
+                if ($isMultiple) {
+                    $def['resolve'] = function ($root, $args) use ($field) {
+                        if (!is_array($root[$field['name']])) return [];
+                    };
+                }
                 break;
         }
 

--- a/Types/FieldType.php
+++ b/Types/FieldType.php
@@ -204,6 +204,7 @@ class FieldType {
                 if ($isMultiple) {
                     $def['resolve'] = function ($root, $args) use ($field) {
                         if (!is_array($root[$field['name']])) return [];
+                        return $root[$field['name']];
                     };
                 }
                 break;

--- a/Types/FieldType.php
+++ b/Types/FieldType.php
@@ -199,40 +199,7 @@ class FieldType {
                 }
 
                 $linkType = self::collectionLinkFieldType($field['options']['link'], $field, $collection);
-
-                if (isset($field['options']['multiple']) && $field['options']['multiple']) {
-                    $def['type'] =  Type::listOf($linkType);
-                    $def['args'] = [
-                        'limit' => Type::int(),
-                        'skip' => Type::int(),
-                        'sort' => JsonType::instance(),
-                    ];
-                    $def['resolve'] = function ($root, $args) use ($field) {
-                        if (!is_array($root[$field['name']])) return [];
-
-                        $options = [
-                            'filter' => [
-                                '_id' => [
-                                    '$in' => array_column($root[$field['name']], '_id')
-                                ]
-                            ]
-                        ];
-
-                        if (isset($args['limit'])) $options['limit'] = $args['limit'];
-                        if (isset($args['skip'])) $options['skip'] = $args['skip'];
-                        if (isset($args['sort'])) $options['sort'] = $args['sort'];
-
-                        return cockpit('collections')->find($field['options']['link'], $options);
-                    };
-                } else {
-                    $def['type'] = $linkType;
-                    $def['resolve'] = function ($root) use ($field) {
-                        return cockpit('collections')->findOne($field['options']['link'], [
-                            '_id' => $root[$field['name']]['_id']
-                        ]);
-                    };
-                }
-
+                $def['type'] = $linkType;
                 break;
         }
 

--- a/admin.php
+++ b/admin.php
@@ -18,5 +18,10 @@ $app->on('admin.init', function() {
     $this->on('cockpit.menu.aside', function() {
         $this->renderView("cockpitql:views/partials/menu.php");
     });
-
+    $this->helper('admin')->addMenuItem('modules', [
+      'label' => 'CockpitQL',
+      'icon'  => 'cockpitql:icon.svg',
+      'route' => '/cockpitql/playground',
+      'active' => strpos($this['route'], '/cockpitql/playground') === 0
+    ]);
 });


### PR DESCRIPTION
Remove resolver of `collectionlink` field, since it can be populated (and localized) through `collections` or `singletons` resolver.