### PR TITLE
Update Error parseLiteral $valueNode

### DIFF
--- a/Types/JsonType.php
+++ b/Types/JsonType.php
@@ -33,7 +33,7 @@ class JsonType extends ScalarType
         return $this->identity($value);
     }
 
-    public function parseLiteral($valueNode, array $variables = null) {
+    public function parseLiteral(Node $valueNode, array $variables = null) {
 
         switch ($valueNode) {
             case ($valueNode instanceof StringValueNode):


### PR DESCRIPTION
The following error occurred, as the statement was not compatible.

"<br />\n<b>Fatal error</b>:  Declaration of CockpitQL\\Types\\JsonType::parseLiteral($valueNode, ?array $variables = NULL) must be compatible with GraphQL\\Type\\Definition\\LeafType::parseLiteral(GraphQL\\Language\\AST\\**Node** $valueNode, ?array $variables = NULL) in <b>cockipit/addons/CockpitQL/Types/JsonType.php</b> on line <b>72</b><br />\n"

Sorry for the language, I'm Brazilian and I'm using the Google translator.

:)